### PR TITLE
ClassicPress Support

### DIFF
--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@ $report = new Report($db, $slug, $_GET);
 $charts = [
 	'activeInstalls' => $report->getChart('total_hits')->renameEmptyValueSeries('Unique sites'),
 	'activeVersions' => $report->getActiveVersionChart(),
-	'wordPressVersions' => $report->getWordPressVersionChart(),
+	'cmsVersions' => $report->getCMSVersionChart(),
 	'phpVersions' => $report->getPhpVersionChart(),
 	'requests' => $report->getRequestChart(),
 ];
@@ -53,7 +53,7 @@ $requestsPerSecond = $report->getTotalRequests() / $report->getDateRange()->getD
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
-	<title>WP Update Server Stats - <?php echo htmlentities($report->getSlug()); ?></title>
+	<title>WP / CP Update Server Stats - <?php echo htmlentities($report->getSlug()); ?></title>
 
 	<!-- Bootstrap -->
 	<link href="vendor/twbs/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -143,8 +143,8 @@ $requestsPerSecond = $report->getTotalRequests() / $report->getDateRange()->getD
 			drawAreaChart('active-version-history', chartData.activeVersions.area);
 			drawPieChart('active-version-pie', chartData.activeVersions.pie);
 
-			drawAreaChart('wordpress-version-history', chartData.wordPressVersions.area);
-			drawPieChart('wordpress-version-pie', chartData.wordPressVersions.pie);
+			drawAreaChart('cms-version-history', chartData.cmsVersions.area);
+			drawPieChart('cms-version-pie', chartData.cmsVersions.pie);
 
 			drawAreaChart('php-version-history', chartData.phpVersions.area);
 			drawPieChart('php-version-pie', chartData.phpVersions.pie);
@@ -334,14 +334,14 @@ $requestsPerSecond = $report->getTotalRequests() / $report->getDateRange()->getD
 		</div>
 
 		<div class="row">
-			<div class="col-md-12"><h2>WordPress versions</h2></div>
+			<div class="col-md-12"><h2>CMS versions</h2></div>
 		</div>
 		<div class="row">
 			<div class="col-md-9">
-				<div id="wordpress-version-history" class="chart area-chart"></div>
+				<div id="cms-version-history" class="chart area-chart"></div>
 			</div>
 			<div class="col-md-3">
-				<div id="wordpress-version-pie" class="chart"></div>
+				<div id="cms-version-pie" class="chart"></div>
 			</div>
 		</div>
 
@@ -372,8 +372,8 @@ $requestsPerSecond = $report->getTotalRequests() / $report->getDateRange()->getD
 		<div class="row">
 		<?php
 		$combos = [
-			'WordPress vs Package version' => [
-				'WordPress' => 'wp_version_aggregate',
+			'CMS vs Package version' => [
+				'CMS' => 'cms_version_aggregate',
 				'Package version' => 'installed_version',
 			],
 			'PHP vs Package version' => [

--- a/index.php
+++ b/index.php
@@ -53,7 +53,7 @@ $requestsPerSecond = $report->getTotalRequests() / $report->getDateRange()->getD
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
-	<title>WP / CP Update Server Stats - <?php echo htmlentities($report->getSlug()); ?></title>
+	<title>Update Server Stats - <?php echo htmlentities($report->getSlug()); ?></title>
 
 	<!-- Bootstrap -->
 	<link href="vendor/twbs/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/src/BasicLogAnalyser.php
+++ b/src/BasicLogAnalyser.php
@@ -273,13 +273,11 @@ class BasicLogAnalyser {
 
 
 		if ( preg_match('/^\[(?P<timestamp>[^\]]+)\]\s(?P<ip>\S+)\s+(?P<remainder>.+)$/', $line, $matches) ) {
+			
 			$result['timestamp'] = strtotime($matches['timestamp']);
 			$result['ip'] = $matches['ip'];
 
-
-			$values = explode("\t", $matches['remainder']);		
-			
-			
+			$values = explode("\t", $matches['remainder']);
 			
 			foreach($values as $index => $value) {
 				if ( isset($columns[$index]) ) {
@@ -321,8 +319,8 @@ class BasicLogAnalyser {
 							$param = array();
 							foreach ($parts as $key => $value) {
 								$compatible = explode('=', $value)[0];
-								$classic_press_version = explode('=', $value)[1];
-								$param[$compatible] = $classic_press_version;
+								$classicPressVersion = explode('=', $value)[1];
+								$param[$compatible] = $classicPressVersion;
 							}
 
 							if($param['wp_compatible']){							
@@ -350,8 +348,9 @@ class BasicLogAnalyser {
 			 * If there is not CMS detected, we assume WordPress
 			 *
 			 */			
-			if(!isset($result['cms']))
+			if(!isset($result['cms'])){
 				$result['cms'] = 'WP';
+			}
 
 
 			//Some sites obfuscate their WordPress version number or replace it with something weird. We don't

--- a/src/LogParserCli.php
+++ b/src/LogParserCli.php
@@ -30,6 +30,7 @@ class LogParserCli {
 			"Peak memory usage: %.2f MiB\n",
 			memory_get_peak_usage(true) / (1024 * 1024)
 		);
+
 	}
 
 	/**

--- a/src/Report.php
+++ b/src/Report.php
@@ -55,9 +55,9 @@ class Report {
 		}, __METHOD__);
 	}
 
-	public function getWordPressVersionChart() {
+	public function getCMSVersionChart() {
 		return $this->cache(function() {
-			return $this->getChart('wp_version_aggregate', array($this, 'compareVersionsDesc'), 'unique_sites', 0.09);
+			return $this->getChart('cms_version_aggregate', array($this, 'compareVersionsDesc'), 'unique_sites', 0.09);
 		}, __METHOD__);
 	}
 
@@ -91,7 +91,7 @@ class Report {
 			':metric' => $metricName,
 			':fromDate' => $this->dateRange->startDate(),
 			':toDate' => $this->dateRange->endDate(),
-		]);
+		]);		
 
 		return new ChartData(
 			$this->metricQuery->fetchAll(PDO::FETCH_ASSOC),


### PR DESCRIPTION
Hello YahnisElsts,

I did some changes to display the charts when ClassicPress is detected,

This only work if the Log's Query_string has the parameter "cms", if there is not cms the LogAnalyser assume WordPress.

Just like i told you, is needed to add the "cms" to the $UpdateChecker:

```
$url = ...
$url .= '&cms=' . self::detect_cms();
$UpdateChecker = Puc_v4_Factory::buildUpdateChecker($url,$target,$slug);
```

```
private static function detect_cms() {
    return (function_exists('classicpress_version_short')) ? 'ClassicPress': 'WordPress';
}

```

Please let me know if these changes works, or if there is fixes to apply.

Regards,